### PR TITLE
Potential fix for nested subparsers not parsing correctly.

### DIFF
--- a/borgmatic/commands/arguments.py
+++ b/borgmatic/commands/arguments.py
@@ -48,7 +48,7 @@ def parse_subparser_arguments(unparsed_arguments, subparsers):
     if 'borg' in unparsed_arguments:
         subparsers = {'borg': subparsers['borg']}
 
-    for argument in reversed(remaining_arguments):
+    for argument in remaining_arguments:
         canonical_name = alias_to_subparser_name.get(argument, argument)
         subparser = subparsers.get(canonical_name)
 
@@ -58,7 +58,9 @@ def parse_subparser_arguments(unparsed_arguments, subparsers):
         # If a parsed value happens to be the same as the name of a subparser, remove it from the
         # remaining arguments. This prevents, for instance, "check --only extract" from triggering
         # the "extract" subparser.
-        parsed, unused_remaining = subparser.parse_known_args(unparsed_arguments)
+        parsed, unused_remaining = subparser.parse_known_args(
+            [argument for argument in unparsed_arguments if argument != canonical_name]
+        )
         for value in vars(parsed).values():
             if isinstance(value, str):
                 if value in subparsers:
@@ -85,7 +87,9 @@ def parse_subparser_arguments(unparsed_arguments, subparsers):
             continue
 
         subparser = subparsers[subparser_name]
-        unused_parsed, remaining_arguments = subparser.parse_known_args(remaining_arguments)
+        unused_parsed, remaining_arguments = subparser.parse_known_args(
+            [argument for argument in remaining_arguments if argument != subparser_name]
+        )
 
     # Special case: If "borg" is present in the arguments, consume all arguments after (+1) the
     # "borg" action.


### PR DESCRIPTION
Here's a PR on your PR that _looks_ like it fixes this problem:

```console
$ borgmatic config bootstrap --help

usage: borgmatic config [-h] {bootstrap} ...
borgmatic config: error: argument {bootstrap}: invalid choice: 'config' (choose from 'bootstrap')
Error parsing arguments: /usr/bin/borgmatic config bootstrap --help
...
```

With this change in place, here's what it looks like now:

```console
$ borgmatic config bootstrap --help

usage: borgmatic config bootstrap --repository REPOSITORY [--archive ARCHIVE] [--path PATH [PATH ...]] [--destination PATH]
                                  [--strip-components NUMBER] [--progress] [-h]

Extract a named archive from a borgmatic created repository to the current directory without a configuration file

config bootstrap arguments:
  --repository REPOSITORY
                        Path of repository to extract
...
```

The problem came down to the config parser trying and failing to parse `"config"` out of the command-line arguments when `parse_known_args()` was called, even though no other parsers work that way. (`parse_known_args()` isn't even supposed to error.) I guess it's something particular to parsers that contain nested subparsers...? The "fix" is simply to omit a parser's own name when it's parsing arguments.

BTW, the `reversed()` thing only applied to my own hacked-up original attempt, and doesn't work on your (more correct) approach. So I removed it.

Let me know if this works for you!